### PR TITLE
Fix typescript build errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
       "devDependencies": {
         "@amplitude/ampli": "^1.29.0",
         "@types/babel__traverse": "^7.12.2",
+        "@types/chai": "^5.2.2",
         "@types/diff": "^5.0.9",
         "@types/find-package-json": "^1.2.2",
         "@types/glob": "^8.1.0",
@@ -48,6 +49,7 @@
         "@typescript-eslint/eslint-plugin": "^7.4.0",
         "@typescript-eslint/parser": "^7.4.0",
         "@vscode/test-electron": "^2.4.0",
+        "chai": "^5.2.1",
         "concurrently": "^7.0.0",
         "copyfiles": "^2.4.1",
         "eslint": "^8.57.0",
@@ -1628,11 +1630,28 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
       "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
       "dev": true
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/diff": {
       "version": "5.0.9",
@@ -2814,6 +2833,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3130,6 +3159,23 @@
         "cdl": "bin/cdl.js"
       }
     },
+    "node_modules/chai": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.1.tgz",
+      "integrity": "sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chainsaw": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -3217,6 +3263,16 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
@@ -3835,6 +3891,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -6272,6 +6338,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.0.tgz",
+      "integrity": "sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru_map": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
@@ -7336,6 +7409,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/php-parser": {
@@ -11005,10 +11088,25 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "requires": {
+        "@types/deep-eql": "*"
+      }
+    },
     "@types/debug": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
       "integrity": "sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==",
+      "dev": true
+    },
+    "@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true
     },
     "@types/diff": {
@@ -11883,6 +11981,12 @@
         "is-shared-array-buffer": "^1.0.2"
       }
     },
+    "assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -12092,6 +12196,19 @@
         "redeyed": "~2.1.0"
       }
     },
+    "chai": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.1.tgz",
+      "integrity": "sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      }
+    },
     "chainsaw": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -12156,6 +12273,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
       "dev": true
     },
     "chokidar": {
@@ -12608,6 +12731,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true
     },
     "deep-is": {
@@ -14392,6 +14521,12 @@
         "is-unicode-supported": "^0.1.0"
       }
     },
+    "loupe": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.0.tgz",
+      "integrity": "sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==",
+      "dev": true
+    },
     "lru_map": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
@@ -15210,6 +15345,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
+    "pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true
     },
     "php-parser": {

--- a/package.json
+++ b/package.json
@@ -516,6 +516,7 @@
   "devDependencies": {
     "@amplitude/ampli": "^1.29.0",
     "@types/babel__traverse": "^7.12.2",
+    "@types/chai": "^5.2.2",
     "@types/diff": "^5.0.9",
     "@types/find-package-json": "^1.2.2",
     "@types/glob": "^8.1.0",
@@ -532,6 +533,7 @@
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",
     "@vscode/test-electron": "^2.4.0",
+    "chai": "^5.2.1",
     "concurrently": "^7.0.0",
     "copyfiles": "^2.4.1",
     "eslint": "^8.57.0",

--- a/src/snyk/cli/checksum.ts
+++ b/src/snyk/cli/checksum.ts
@@ -18,7 +18,7 @@ export class Checksum {
   }
 
   update(buffer: Buffer): void {
-    this.hash.update(buffer);
+    this.hash.update(new Uint8Array(buffer));
   }
 
   digest(): Checksum {

--- a/src/snyk/snykCode/utils/ignoreFileUtils.ts
+++ b/src/snyk/snykCode/utils/ignoreFileUtils.ts
@@ -18,7 +18,7 @@ export const createDCIgnore = async (
   const filePath = `${path}/${dcIgnoreConstant.DCIGNORE_FILENAME}`;
   const openPath = uriAdapter.file(filePath);
   // We don't want to override the dcignore file with an empty one.
-  if (!custom || !fs.existsSync(filePath)) await workspace.fs.writeFile(openPath, content);
+  if (!custom || !fs.existsSync(filePath)) await workspace.fs.writeFile(openPath, new Uint8Array(content));
   const doc = await workspace.openTextDocumentViaUri(openPath);
   void window.showTextDocument(doc);
 };


### PR DESCRIPTION
### Description

This PR resolves critical build errors preventing the project from compiling successfully. The issues stemmed from:

1.  **Buffer Type Incompatibility**: Stricter TypeScript type checking in newer Node.js environments caused `Buffer` types to be incompatible with `crypto.Hash.update` and `workspace.fs.writeFile`. This is resolved by explicitly converting `Buffer` instances to `Uint8Array`.
2.  **Missing Test Dependency**: The `chai` testing library and its type definitions were missing, leading to a "Cannot find module 'chai'" error during the build. This is fixed by adding `chai` and `@types/chai` as development dependencies.

These changes ensure the project builds successfully and is compatible with current development environments.

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/vscode-extension/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/vscode-extension/blob/main/CONTRIBUTING.md).
- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_Visuals that may help the reviewer. Please add screenshots for any UI change. GIFs are most welcome!_

---

[Open in Web](https://www.cursor.com/agents?id=bc-6d3e3611-4638-4768-8d17-2b6510c79f0e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6d3e3611-4638-4768-8d17-2b6510c79f0e)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)