### PR TITLE
Fix vscode extension activation error

### DIFF
--- a/package.json
+++ b/package.json
@@ -497,7 +497,7 @@
   "scripts": {
     "vscode:prepublish": "tsc -p ./ && sass media --no-source-map && npm run copy-i18n",
     "build": "npm run vscode:prepublish",
-    "copy-i18n": "copyfiles -u 1 src/i18n/*.json out/i18n/",
+    "copy-i18n": "copyfiles -u 2 src/i18n/*.json out/i18n/",
     "clean": "rm -rf ./out",
     "rebuild": "npm run clean && npm run build",
     "watch": "tsc -watch -p ./",


### PR DESCRIPTION
```
### Description

Fixes an extension activation error "Cannot find module './oss.en.json'". The issue was caused by i18n JSON files being copied to an incorrect nested directory (`out/i18n/i18n/`) during the build process. This PR updates the `copy-i18n` script in `package.json` to use `copyfiles -u 2` instead of `-u 1`, ensuring the files are copied directly to `out/i18n/` as expected by the extension.

### Checklist

- [ ] Read and understood the [Code of Conduct](https://github.com/snyk/vscode-extension/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/snyk/vscode-extension/blob/main/CONTRIBUTING.md).
- [ ] Tests added and all succeed
- [ ] Linted
- [ ] CHANGELOG.md updated
- [ ] README.md updated, if user-facing

### Screenshots / GIFs

_N/A_
```

---

[Open in Web](https://www.cursor.com/agents?id=bc-a0090bd3-addf-493a-abb9-a68784a25382) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a0090bd3-addf-493a-abb9-a68784a25382)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)